### PR TITLE
fix travis script. disable coverage task when Scala 2.10.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ scala:
 - 2.10.4
 - 2.11.5
 sudo: false
-script: sbt clean coverage test
-after_success: sbt coveralls
+script: sbt ++${TRAVIS_SCALA_VERSION} clean $(if [[ "${TRAVIS_SCALA_VERSION}" == "2.11.5" ]]; then echo coverage ; else echo "" ; fi) test
+after_success: sbt $(if [[ "${TRAVIS_SCALA_VERSION}" == "2.11.5" ]]; then echo coveralls ; else echo "" ; fi)
 addons:
   postgresql: '9.3'
 before_script:


### PR DESCRIPTION
coverage task with Scala 2.10.4 does not work

https://travis-ci.org/xuwei-k/scalikejdbc-async/jobs/50727149#L1755

```
[info] ======= Position error
[info] Synthetic tree [16042] contains nonsynthetic tree [16041]
[info] == Enclosing tree [16042] of type Select at [937]Company.scala
[info] 
[info] [L  24        ] #16042  [937]           Select     // Select(Ident(c), field)
[info] 
[info] == Enclosed tree [16041] of type Ident at [937:938]Company.scala
[info] 
[info] [L  24        ] #16041  [937:938]       Ident      // c.
[info] 
[info] 
[info] While validating #17691
[info] [L   1        ] #17691  [0:3577]        PackageDef // models
[info] 
[info] Children:
[info]   [L   1 P#17691] #1158   [8:14]          Ident      // models
[info]   [L   3 P#17691] #1160   [16:36]         Import     // scalikejdbc._, async.
[info]   [L   3 P#17691] #9878   [38:45]         Import     // async._,
[info]   [L   3 P#17691] #9882   [47:64]         Import     // FutureImplicits._
[info]   [L   4 P#17691] #1167   [65:90]         Import     // scala.concurrent._
[info]   [L   5 P#17691] #1171   [91:120]        Import     // org.joda.time.DateTime
[info]   [L   7 P#17691] #15877  [122:584]       ClassDef   // Company(
[info]   [L  18 P#17691] #17690  [586:3577]      ModuleDef  // Company extends SQLSyntaxSupport[Company] with ShortenedNames {
[info] =======
[error] 
[error]      while compiling: /home/travis/build/xuwei-k/scalikejdbc-async/play-sample/app/models/Company.scala
[error]         during phase: typer
[error]      library version: version 2.10.4
[error]     compiler version: version 2.10.4
[error]   reconstructed args: -encoding utf8 -bootclasspath /usr/lib/jvm/java-7-oracle/jre/lib/resources.jar:/usr/lib/jvm/java-7-oracle/jre/lib/rt.jar:/usr/lib/jvm/java-7-oracle/jre/lib/sunrsasign.jar:/usr/lib/jvm/java-7-oracle/jre/lib/jsse.jar:/usr/lib/jvm/java-7-oracle/jre/lib/jce.jar:/usr/lib/jvm/java-7-oracle/jre/lib/charsets.jar:/usr/lib/jvm/java-7-oracle/jre/lib/jfr.jar:/usr/lib/jvm/java-7-oracle/jre/classes:/home/travis/.sbt/boot/scala-2.10.4/lib/scala-library.jar -classpath /home/travis/build/xuwei-k/scalikejdbc-async/play-sample/target/scala-2.10/classes:/home/travis/build/xuwei-k/scalikejdbc-async/core/target/scala-2.10/classes:/home/travis/build/xuwei-k/scalikejdbc-async/play-plugin/target/scala-2.10/classes:/home/travis/.ivy2/cache/org.scalikejdbc/scalikejdbc_2.10/jars/scalikejdbc_2.10-2.2.3.jar:/home/travis/.ivy2/cache/org.scalikejdbc/scalikejdbc-core_2.10/jars/scalikejdbc-core_2.10-2.2.3.jar:/home/travis/.ivy2/cache/commons-dbcp/commons-dbcp/jars/commons-dbcp-1.4.jar:/home/travis/.ivy2/cache/commons-pool/commons-pool/jars/commons-pool-1.5.4.jar:/home/travis/.ivy2/cache/org.slf4j/slf4j-api/jars/slf4j-api-1.7.10.jar:/home/travis/.ivy2/cache/joda-time/joda-time/jars/joda-time-2.6.jar:/home/travis/.ivy2/cache/org.joda/joda-convert/jars/joda-convert-1.7.jar:/home/travis/.ivy2/cache/org.scalikejdbc/scalikejdbc-interpolation_2.10/jars/scalikejdbc-interpolation_2.10-2.2.3.jar:/home/travis/.ivy2/cache/org.scalikejdbc/scalikejdbc-interpolation-macro_2.10/jars/scalikejdbc-interpolation-macro_2.10-2.2.3.jar:/home/travis/.sbt/boot/scala-2.10.4/lib/scala-reflect.jar:/home/travis/.ivy2/cache/com.typesafe.play/twirl-api_2.10/jars/twirl-api_2.10-1.0.2.jar:/home/travis/.ivy2/cache/org.apache.commons/commons-lang3/jars/commons-lang3-3.1.jar:/home/travis/.ivy2/cache/com.typesafe.play/play_2.10/jars/play_2.10-2.3.7.jar:/home/travis/.ivy2/cache/com.typesafe.play/build-link/jars/build-link-2.3.7.jar:/home/travis/.ivy2/cache/com.typesafe.play/play-exceptions/jars/play-exceptions-2.3.7.jar:/home/travis/.ivy2/cache/org.javassist/javassist/bundles/javassist-3.18.2-GA.jar:/home/travis/.ivy2/cache/com.typesafe.play/play-iteratees_2.10/jars/play-iteratees_2.10-2.3.7.jar:/home/travis/.ivy2/cache/org.scala-stm/scala-stm_2.10/jars/scala-stm_2.10-0.7.jar:/home/travis/.ivy2/cache/com.typesafe/config/bundles/config-1.2.1.jar:/home/travis/.ivy2/cache/com.typesafe.play/play-json_2.10/jars/play-json_2.10-2.3.7.jar:/home/travis/.ivy2/cache/com.typesafe.play/play-functional_2.10/jars/play-functional_2.10-2.3.7.jar:/home/travis/.ivy2/cache/com.typesafe.play/play-datacommons_2.10/jars/play-datacommons_2.10-2.3.7.jar:/home/travis/.ivy2/cache/com.fasterxml.jackson.core/jackson-annotations/bundles/jackson-annotations-2.3.2.jar:/home/travis/.ivy2/cache/com.fasterxml.jackson.core/jackson-core/bundles/jackson-core-2.3.2.jar:/home/travis/.ivy2/cache/com.fasterxml.jackson.core/jackson-databind/bundles/jackson-databind-2.3.2.jar:/home/travis/.ivy2/cache/io.netty/netty/bundles/netty-3.9.3.Final.jar:/home/travis/.ivy2/cache/com.typesafe.netty/netty-http-pipelining/jars/netty-http-pipelining-1.1.2.jar:/home/travis/.ivy2/cache/org.slf4j/jul-to-slf4j/jars/jul-to-slf4j-1.7.6.jar:/home/travis/.ivy2/cache/org.slf4j/jcl-over-slf4j/jars/jcl-over-slf4j-1.7.6.jar:/home/travis/.ivy2/cache/ch.qos.logback/logback-core/jars/logback-core-1.1.1.jar:/home/travis/.ivy2/cache/ch.qos.logback/logback-classic/jars/logback-classic-1.1.1.jar:/home/travis/.ivy2/cache/com.typesafe.akka/akka-actor_2.10/jars/akka-actor_2.10-2.3.4.jar:/home/travis/.ivy2/cache/com.typesafe.akka/akka-slf4j_2.10/jars/akka-slf4j_2.10-2.3.4.jar:/home/travis/.ivy2/cache/commons-codec/commons-codec/jars/commons-codec-1.9.jar:/home/travis/.ivy2/cache/xerces/xercesImpl/jars/xercesImpl-2.11.0.jar:/home/travis/.ivy2/cache/xml-apis/xml-apis/jars/xml-apis-1.4.01.jar:/home/travis/.ivy2/cache/javax.transaction/jta/jars/jta-1.1.jar:/home/travis/.ivy2/cache/org.scalikejdbc/scalikejdbc-config_2.10/jars/scalikejdbc-config_2.10-2.2.3.jar:/home/travis/.ivy2/cache/com.github.mauricio/postgresql-async_2.10/jars/postgresql-async_2.10-0.2.15.jar:/home/travis/.ivy2/cache/com.github.mauricio/db-async-common_2.10/jars/db-async-common_2.10-0.2.15.jar:/home/travis/.ivy2/cache/io.netty/netty-all/jars/netty-all-4.0.23.Final.jar:/home/travis/.ivy2/cache/com.github.mauricio/mysql-async_2.10/jars/mysql-async_2.10-0.2.15.jar:/home/travis/.ivy2/cache/org.postgresql/postgresql/jars/postgresql-9.3-1102-jdbc41.jar:/home/travis/.ivy2/cache/com.github.tototoshi/play-flyway_2.10/jars/play-flyway_2.10-1.2.1.jar:/home/travis/.ivy2/cache/org.flywaydb/flyway-core/jars/flyway-core-3.1.jar:/home/travis/.ivy2/cache/mysql/mysql-connector-java/jars/mysql-connector-java-5.1.34.jar:/home/travis/.ivy2/cache/org.json4s/json4s-ext_2.10/jars/json4s-ext_2.10-3.2.11.jar:/home/travis/.ivy2/cache/com.github.tototoshi/play-json4s-native_2.10/jars/play-json4s-native_2.10-0.3.1.jar:/home/travis/.ivy2/cache/com.github.tototoshi/play-json4s-core_2.10/jars/play-json4s-core_2.10-0.3.1.jar:/home/travis/.ivy2/cache/org.json4s/json4s-core_2.10/jars/json4s-core_2.10-3.2.11.jar:/home/travis/.ivy2/cache/org.json4s/json4s-ast_2.10/jars/json4s-ast_2.10-3.2.11.jar:/home/travis/.ivy2/cache/com.thoughtworks.paranamer/paranamer/jars/paranamer-2.6.jar:/home/travis/.ivy2/cache/org.scala-lang/scalap/jars/scalap-2.10.0.jar:/home/travis/.ivy2/cache/org.scala-lang/scala-compiler/jars/scala-compiler-2.10.0.jar:/home/travis/.ivy2/cache/org.json4s/json4s-native_2.10/jars/json4s-native_2.10-3.2.11.jar:/home/travis/.ivy2/cache/org.scoverage/scalac-scoverage-runtime_2.10/jars/scalac-scoverage-runtime_2.10-1.0.4.jar:/home/travis/.ivy2/cache/org.scoverage/scalac-scoverage-plugin_2.10/jars/scalac-scoverage-plugin_2.10-1.0.4.jar -deprecation -Yrangepos -Xplugin:/home/travis/.ivy2/cache/org.scoverage/scalac-scoverage-plugin_2.10/jars/scalac-scoverage-plugin_2.10-1.0.4.jar -P:scoverage:dataDir:/home/travis/build/xuwei-k/scalikejdbc-async/play-sample/target/scala-2.10/scoverage-data -unchecked
[error] 
[error]   last tree to typer: Select(This(package models), Company)
[error]               symbol: object Company in package models (flags: <module> <triedcooking>)
[error]    symbol definition: object Company
[error]                  tpe: models.Company.type
[error]        symbol owners: object Company -> package models
[error]       context owners: method readResolve -> object Company -> package models
[error] 
[error] == Enclosing template or block ==
[error] 
[error] DefDef( // private def readResolve(): Object in object Company
[error]   <method> private <synthetic>
[error]   "readResolve"
[error]   []
[error]   List(Nil)
[error]   <tpt> // tree.tpe=Object
[error]   models.this."Company" // object Company in package models, tree.tpe=models.Company.type
[error] )
[error] 
[error] == Expanded type of tree ==
[error] 
[error] TypeRef(
[error]   TypeSymbol(
[error]     class Company extends SQLSyntaxSupport[models.Company] with ShortenedNames with Serializable
[error]     
[error]   )
[error] )
[error] 
[error] uncaught exception during compilation: scala.tools.nsc.interactive.RangePositions$ValidateException
scala.tools.nsc.interactive.RangePositions$ValidateException: Synthetic tree [16042] contains nonsynthetic tree [16041]
	at scala.tools.nsc.interactive.RangePositions$class.positionError$1(RangePositions.scala:201)
	at scala.tools.nsc.interactive.RangePositions$class.validate$1(RangePositions.scala:218)
	at scala.tools.nsc.interactive.RangePositions$class.validate$1(RangePositions.scala:241)
	at scala.tools.nsc.interactive.RangePositions$class.validate$1(RangePositions.scala:241)
	at scala.tools.nsc.interactive.RangePositions$class.validate$1(RangePositions.scala:241)
	at scala.tools.nsc.interactive.RangePositions$class.validate$1(RangePositions.scala:241)
	at scala.tools.nsc.interactive.RangePositions$class.validate$1(RangePositions.scala:241)
```