### PR TITLE
Fix core's sample specs

### DIFF
--- a/core/src/test/scala/sample/PostgreSQLSampleSpec.scala
+++ b/core/src/test/scala/sample/PostgreSQLSampleSpec.scala
@@ -2,7 +2,6 @@ package sample
 
 import org.joda.time._
 import org.scalatest._
-import org.slf4j.LoggerFactory
 import scala.concurrent._, duration.DurationInt, ExecutionContext.Implicits.global
 import scalikejdbc._, async._
 import unit._

--- a/core/src/test/scala/sample/PostgreSQLSampleSpec.scala
+++ b/core/src/test/scala/sample/PostgreSQLSampleSpec.scala
@@ -119,7 +119,7 @@ class PostgreSQLSampleSpec extends FlatSpec with Matchers with DBSettings with L
     Await.result(deletion, 5.seconds)
 
     // should be committed
-    val deleted = NamedDB('mysql).readOnly { implicit s =>
+    val deleted = DB.readOnly { implicit s =>
       withSQL { select.from(AsyncLover as al).where.eq(al.id, 1004) }.map(AsyncLover(al)).single.apply()
     }
     deleted.isDefined should be(false)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -5,7 +5,7 @@ object ScalikeJDBCAsyncProject extends Build {
 
   lazy val _version = "0.6.0-SNAPSHOT"
   lazy val scalikejdbcVersion = "2.2.9"
-  lazy val mauricioVersion = "0.2.+" // provided
+  lazy val mauricioVersion = "0.2.18" // provided
   lazy val postgresqlVersion = "9.4-1201-jdbc41"
   lazy val defaultPlayVersion = play.core.PlayVersion.current
 


### PR DESCRIPTION
This trivial PR fixes what looks like copy-paste errors in sample specs of `core` and removes one unused import.

~~Because of the #32, tests probably will not pass on Travis for this PR, so I've created [separate branch](https://github.com/sainaen/scalikejdbc-async/commits/fix_sample_specs_v) with this changes and applied the fix for Travis, and the resulting build is [green](https://travis-ci.org/sainaen/scalikejdbc-async/builds/104705140).~~
Now it includes the fix for #32, so build passes on Travis.

I didn't find CONTRIBUTING.md or something like that, so I'm submitting it as is, but if it's prefered I'd be happy to update commit messages and/or squash all changes into one commit.