### PR TITLE
prepare Scala 2.13

### DIFF
--- a/core/src/main/scala/scalikejdbc/async/AsyncDBSession.scala
+++ b/core/src/main/scala/scalikejdbc/async/AsyncDBSession.scala
@@ -84,13 +84,17 @@ trait AsyncDBSession extends LogSupport {
     }
   }
 
-  def traversable[A](statement: String, parameters: Any*)(extractor: WrappedResultSet => A)(implicit cxt: EC = ECGlobal): Future[Traversable[A]] = {
+  @deprecated("will be removed. use iterable", "0.12.0")
+  def traversable[A](statement: String, parameters: Any*)(extractor: WrappedResultSet => A)(implicit cxt: EC = ECGlobal): Future[Iterable[A]] =
+    iterable[A](statement, parameters: _*)(extractor)
+
+  def iterable[A](statement: String, parameters: Any*)(extractor: WrappedResultSet => A)(implicit cxt: EC = ECGlobal): Future[Iterable[A]] = {
     val _parameters = ensureAndNormalizeParameters(parameters)
     withListeners(statement, _parameters) {
       queryLogging(statement, _parameters)
       connection.sendPreparedStatement(statement, _parameters: _*).map { result =>
         result.rows.map { ars =>
-          new AsyncResultSetTraversable(ars).map(rs => extractor(rs))
+          new AsyncResultSetIterator(ars).map(rs => extractor(rs)).toList
         }.getOrElse(Nil)
       }
     }
@@ -100,7 +104,7 @@ trait AsyncDBSession extends LogSupport {
     implicit
     cxt: EC = ECGlobal): Future[Option[A]] = {
     val _parameters = ensureAndNormalizeParameters(parameters)
-    traversable(statement, _parameters: _*)(extractor).map { results =>
+    iterable(statement, _parameters: _*)(extractor).map { results =>
       results match {
         case Nil => None
         case one :: Nil => Option(one)
@@ -111,12 +115,18 @@ trait AsyncDBSession extends LogSupport {
 
   def list[A](statement: String, parameters: Any*)(extractor: WrappedResultSet => A)(implicit cxt: EC = ECGlobal): Future[List[A]] = {
     val _parameters = ensureAndNormalizeParameters(parameters)
-    (traversable[A](statement, _parameters: _*)(extractor)).map(_.toList)
+    (iterable[A](statement, _parameters: _*)(extractor)).map(_.toList)
   }
 
-  def oneToOneTraversable[A, B, Z](statement: String, parameters: Any*)(extractOne: (WrappedResultSet) => A)(extractTo: (WrappedResultSet) => Option[B])(transform: (A, B) => Z)(
+  @deprecated("will be removed. use oneToOneIterable", "0.12.0")
+  def oneToOneTraversable[A, B, Z](statement: String, parameters: Any*)(extractOne: WrappedResultSet => A)(extractTo: WrappedResultSet => Option[B])(transform: (A, B) => Z)(
     implicit
-    cxt: EC = ECGlobal): Future[Traversable[Z]] = {
+    cxt: EC = ECGlobal): Future[Iterable[Z]] =
+    oneToOneIterable[A, B, Z](statement, parameters: _*)(extractOne)(extractTo)(transform)
+
+  def oneToOneIterable[A, B, Z](statement: String, parameters: Any*)(extractOne: WrappedResultSet => A)(extractTo: WrappedResultSet => Option[B])(transform: (A, B) => Z)(
+    implicit
+    cxt: EC = ECGlobal): Future[Iterable[Z]] = {
     val _parameters = ensureAndNormalizeParameters(parameters)
     withListeners(statement, _parameters) {
       queryLogging(statement, _parameters)
@@ -130,7 +140,7 @@ trait AsyncDBSession extends LogSupport {
       }
       connection.sendPreparedStatement(statement, _parameters: _*).map { result =>
         result.rows.map { ars =>
-          new AsyncResultSetTraversable(ars).foldLeft(LinkedHashMap[A, Option[B]]())(processResultSet).map {
+          new AsyncResultSetIterator(ars).foldLeft(LinkedHashMap[A, Option[B]]())(processResultSet).map {
             case (one, Some(to)) => transform(one, to)
             case (one, None) => one.asInstanceOf[Z]
           }
@@ -139,12 +149,21 @@ trait AsyncDBSession extends LogSupport {
     }
   }
 
+  @deprecated("will be removed. use oneToManyIterable", "0.12.0")
   def oneToManyTraversable[A, B, Z](statement: String, parameters: Any*)(
-    extractOne: (WrappedResultSet) => A)(
-    extractTo: (WrappedResultSet) => Option[B])(
+    extractOne: WrappedResultSet => A)(
+    extractTo: WrappedResultSet => Option[B])(
     transform: (A, Seq[B]) => Z)(
     implicit
-    cxt: EC = ECGlobal): Future[Traversable[Z]] = {
+    cxt: EC = ECGlobal): Future[Iterable[Z]] =
+    oneToManyIterable[A, B, Z](statement, parameters: _*)(extractOne)(extractTo)(transform)
+
+  def oneToManyIterable[A, B, Z](statement: String, parameters: Any*)(
+    extractOne: WrappedResultSet => A)(
+    extractTo: WrappedResultSet => Option[B])(
+    transform: (A, Seq[B]) => Z)(
+    implicit
+    cxt: EC = ECGlobal): Future[Iterable[Z]] = {
     val _parameters = ensureAndNormalizeParameters(parameters)
     withListeners(statement, _parameters) {
       queryLogging(statement, _parameters)
@@ -159,7 +178,7 @@ trait AsyncDBSession extends LogSupport {
       }
       connection.sendPreparedStatement(statement, _parameters: _*).map { result =>
         result.rows.map { ars =>
-          new AsyncResultSetTraversable(ars).foldLeft(LinkedHashMap[A, Seq[B]]())(processResultSet).map {
+          new AsyncResultSetIterator(ars).foldLeft(LinkedHashMap[A, Seq[B]]())(processResultSet).map {
             case (one, to) => transform(one, to)
           }
         }.getOrElse(Nil)
@@ -167,13 +186,23 @@ trait AsyncDBSession extends LogSupport {
     }
   }
 
+  @deprecated("will be removed. use oneToManies2Iterable", "0.12.0")
   def oneToManies2Traversable[A, B1, B2, Z](statement: String, parameters: Any*)(
-    extractOne: (WrappedResultSet) => A)(
-    extractTo1: (WrappedResultSet) => Option[B1],
-    extractTo2: (WrappedResultSet) => Option[B2])(
+    extractOne: WrappedResultSet => A)(
+    extractTo1: WrappedResultSet => Option[B1],
+    extractTo2: WrappedResultSet => Option[B2])(
     transform: (A, Seq[B1], Seq[B2]) => Z)(
     implicit
-    cxt: EC = ECGlobal): Future[Traversable[Z]] = {
+    cxt: EC = ECGlobal): Future[Iterable[Z]] =
+    oneToManies2Iterable[A, B1, B2, Z](statement, parameters: _*)(extractOne)(extractTo1, extractTo2)(transform)
+
+  def oneToManies2Iterable[A, B1, B2, Z](statement: String, parameters: Any*)(
+    extractOne: WrappedResultSet => A)(
+    extractTo1: WrappedResultSet => Option[B1],
+    extractTo2: WrappedResultSet => Option[B2])(
+    transform: (A, Seq[B1], Seq[B2]) => Z)(
+    implicit
+    cxt: EC = ECGlobal): Future[Iterable[Z]] = {
     val _parameters = ensureAndNormalizeParameters(parameters)
     withListeners(statement, _parameters) {
       queryLogging(statement, _parameters)
@@ -194,7 +223,7 @@ trait AsyncDBSession extends LogSupport {
       }
       connection.sendPreparedStatement(statement, _parameters: _*).map { result =>
         result.rows.map { ars =>
-          new AsyncResultSetTraversable(ars).foldLeft(LinkedHashMap[A, (Seq[B1], Seq[B2])]())(processResultSet).map {
+          new AsyncResultSetIterator(ars).foldLeft(LinkedHashMap[A, (Seq[B1], Seq[B2])]())(processResultSet).map {
             case (one, (t1, t2)) => transform(one, t1, t2)
           }
         }.getOrElse(Nil)
@@ -202,14 +231,25 @@ trait AsyncDBSession extends LogSupport {
     }
   }
 
+  @deprecated("will be removed. use oneToManies3Iterable", "0.12.0")
   def oneToManies3Traversable[A, B1, B2, B3, Z](statement: String, parameters: Any*)(
-    extractOne: (WrappedResultSet) => A)(
-    extractTo1: (WrappedResultSet) => Option[B1],
-    extractTo2: (WrappedResultSet) => Option[B2],
-    extractTo3: (WrappedResultSet) => Option[B3])(
+    extractOne: WrappedResultSet => A)(
+    extractTo1: WrappedResultSet => Option[B1],
+    extractTo2: WrappedResultSet => Option[B2],
+    extractTo3: WrappedResultSet => Option[B3])(
     transform: (A, Seq[B1], Seq[B2], Seq[B3]) => Z)(
     implicit
-    cxt: EC = ECGlobal): Future[Traversable[Z]] = {
+    cxt: EC = ECGlobal): Future[Iterable[Z]] =
+    oneToManies3Iterable[A, B1, B2, B3, Z](statement, parameters: _*)(extractOne)(extractTo1, extractTo2, extractTo3)(transform)
+
+  def oneToManies3Iterable[A, B1, B2, B3, Z](statement: String, parameters: Any*)(
+    extractOne: WrappedResultSet => A)(
+    extractTo1: WrappedResultSet => Option[B1],
+    extractTo2: WrappedResultSet => Option[B2],
+    extractTo3: WrappedResultSet => Option[B3])(
+    transform: (A, Seq[B1], Seq[B2], Seq[B3]) => Z)(
+    implicit
+    cxt: EC = ECGlobal): Future[Iterable[Z]] = {
     val _parameters = ensureAndNormalizeParameters(parameters)
     withListeners(statement, _parameters) {
       queryLogging(statement, _parameters)
@@ -235,7 +275,7 @@ trait AsyncDBSession extends LogSupport {
       }
       connection.sendPreparedStatement(statement, _parameters: _*).map { result =>
         result.rows.map { ars =>
-          new AsyncResultSetTraversable(ars).foldLeft(LinkedHashMap[A, (Seq[B1], Seq[B2], Seq[B3])]())(processResultSet).map {
+          new AsyncResultSetIterator(ars).foldLeft(LinkedHashMap[A, (Seq[B1], Seq[B2], Seq[B3])]())(processResultSet).map {
             case (one, (t1, t2, t3)) => transform(one, t1, t2, t3)
           }
         }.getOrElse(Nil)
@@ -243,15 +283,27 @@ trait AsyncDBSession extends LogSupport {
     }
   }
 
+  @deprecated("will be removed. use oneToManies4Iterable", "0.12.0")
   def oneToManies4Traversable[A, B1, B2, B3, B4, Z](statement: String, parameters: Any*)(
-    extractOne: (WrappedResultSet) => A)(
-    extractTo1: (WrappedResultSet) => Option[B1],
-    extractTo2: (WrappedResultSet) => Option[B2],
-    extractTo3: (WrappedResultSet) => Option[B3],
-    extractTo4: (WrappedResultSet) => Option[B4])(
+    extractOne: WrappedResultSet => A)(
+    extractTo1: WrappedResultSet => Option[B1],
+    extractTo2: WrappedResultSet => Option[B2],
+    extractTo3: WrappedResultSet => Option[B3],
+    extractTo4: WrappedResultSet => Option[B4])(
     transform: (A, Seq[B1], Seq[B2], Seq[B3], Seq[B4]) => Z)(
     implicit
-    cxt: EC = ECGlobal): Future[Traversable[Z]] = {
+    cxt: EC = ECGlobal): Future[Iterable[Z]] =
+    oneToManies4Iterable[A, B1, B2, B3, B4, Z](statement, parameters: _*)(extractOne)(extractTo1, extractTo2, extractTo3, extractTo4)(transform)
+
+  def oneToManies4Iterable[A, B1, B2, B3, B4, Z](statement: String, parameters: Any*)(
+    extractOne: WrappedResultSet => A)(
+    extractTo1: WrappedResultSet => Option[B1],
+    extractTo2: WrappedResultSet => Option[B2],
+    extractTo3: WrappedResultSet => Option[B3],
+    extractTo4: WrappedResultSet => Option[B4])(
+    transform: (A, Seq[B1], Seq[B2], Seq[B3], Seq[B4]) => Z)(
+    implicit
+    cxt: EC = ECGlobal): Future[Iterable[Z]] = {
     val _parameters = ensureAndNormalizeParameters(parameters)
     withListeners(statement, _parameters) {
       queryLogging(statement, _parameters)
@@ -279,7 +331,7 @@ trait AsyncDBSession extends LogSupport {
       }
       connection.sendPreparedStatement(statement, _parameters: _*).map { result =>
         result.rows.map { ars =>
-          new AsyncResultSetTraversable(ars).foldLeft(
+          new AsyncResultSetIterator(ars).foldLeft(
             LinkedHashMap[A, (Seq[B1], Seq[B2], Seq[B3], Seq[B4])]())(processResultSet).map {
               case (one, (t1, t2, t3, t4)) => transform(one, t1, t2, t3, t4)
             }
@@ -288,18 +340,38 @@ trait AsyncDBSession extends LogSupport {
     }
   }
 
+  @deprecated("will be removed. use oneToManies5Iterable", "0.12.0")
   def oneToManies5Traversable[A, B1, B2, B3, B4, B5, Z](
     statement: String,
     parameters: Any*)(
-    extractOne: (WrappedResultSet) => A)(
-    extractTo1: (WrappedResultSet) => Option[B1],
-    extractTo2: (WrappedResultSet) => Option[B2],
-    extractTo3: (WrappedResultSet) => Option[B3],
-    extractTo4: (WrappedResultSet) => Option[B4],
-    extractTo5: (WrappedResultSet) => Option[B5])(
+    extractOne: WrappedResultSet => A)(
+    extractTo1: WrappedResultSet => Option[B1],
+    extractTo2: WrappedResultSet => Option[B2],
+    extractTo3: WrappedResultSet => Option[B3],
+    extractTo4: WrappedResultSet => Option[B4],
+    extractTo5: WrappedResultSet => Option[B5])(
     transform: (A, Seq[B1], Seq[B2], Seq[B3], Seq[B4], Seq[B5]) => Z)(
     implicit
-    cxt: EC = ECGlobal): Future[Traversable[Z]] = {
+    cxt: EC = ECGlobal): Future[Iterable[Z]] =
+    oneToManies5Iterable[A, B1, B2, B3, B4, B5, Z](statement, parameters: _*)(extractOne)(
+      extractTo1,
+      extractTo2,
+      extractTo3,
+      extractTo4,
+      extractTo5)(transform)
+
+  def oneToManies5Iterable[A, B1, B2, B3, B4, B5, Z](
+    statement: String,
+    parameters: Any*)(
+    extractOne: WrappedResultSet => A)(
+    extractTo1: WrappedResultSet => Option[B1],
+    extractTo2: WrappedResultSet => Option[B2],
+    extractTo3: WrappedResultSet => Option[B3],
+    extractTo4: WrappedResultSet => Option[B4],
+    extractTo5: WrappedResultSet => Option[B5])(
+    transform: (A, Seq[B1], Seq[B2], Seq[B3], Seq[B4], Seq[B5]) => Z)(
+    implicit
+    cxt: EC = ECGlobal): Future[Iterable[Z]] = {
     val _parameters = ensureAndNormalizeParameters(parameters)
     withListeners(statement, _parameters) {
       queryLogging(statement, _parameters)
@@ -331,7 +403,7 @@ trait AsyncDBSession extends LogSupport {
       }
       connection.sendPreparedStatement(statement, _parameters: _*).map { result =>
         result.rows.map { ars =>
-          new AsyncResultSetTraversable(ars).foldLeft(
+          new AsyncResultSetIterator(ars).foldLeft(
             LinkedHashMap[A, (Seq[B1], Seq[B2], Seq[B3], Seq[B4], Seq[B5])]())(processResultSet).map {
               case (one, (t1, t2, t3, t4, t5)) => transform(one, t1, t2, t3, t4, t5)
             }
@@ -340,19 +412,41 @@ trait AsyncDBSession extends LogSupport {
     }
   }
 
+  @deprecated("will be removed. use oneToManies6Iterable", "0.12.0")
   def oneToManies6Traversable[A, B1, B2, B3, B4, B5, B6, Z](
     statement: String,
     parameters: Any*)(
-    extractOne: (WrappedResultSet) => A)(
-    extractTo1: (WrappedResultSet) => Option[B1],
-    extractTo2: (WrappedResultSet) => Option[B2],
-    extractTo3: (WrappedResultSet) => Option[B3],
-    extractTo4: (WrappedResultSet) => Option[B4],
-    extractTo5: (WrappedResultSet) => Option[B5],
-    extractTo6: (WrappedResultSet) => Option[B6])(
+    extractOne: WrappedResultSet => A)(
+    extractTo1: WrappedResultSet => Option[B1],
+    extractTo2: WrappedResultSet => Option[B2],
+    extractTo3: WrappedResultSet => Option[B3],
+    extractTo4: WrappedResultSet => Option[B4],
+    extractTo5: WrappedResultSet => Option[B5],
+    extractTo6: WrappedResultSet => Option[B6])(
     transform: (A, Seq[B1], Seq[B2], Seq[B3], Seq[B4], Seq[B5], Seq[B6]) => Z)(
     implicit
-    cxt: EC = ECGlobal): Future[Traversable[Z]] = {
+    cxt: EC = ECGlobal): Future[Iterable[Z]] =
+    oneToManies6Iterable[A, B1, B2, B3, B4, B5, B6, Z](statement, parameters: _*)(extractOne)(
+      extractTo1,
+      extractTo2,
+      extractTo3,
+      extractTo4,
+      extractTo5,
+      extractTo6)(transform)
+
+  def oneToManies6Iterable[A, B1, B2, B3, B4, B5, B6, Z](
+    statement: String,
+    parameters: Any*)(
+    extractOne: WrappedResultSet => A)(
+    extractTo1: WrappedResultSet => Option[B1],
+    extractTo2: WrappedResultSet => Option[B2],
+    extractTo3: WrappedResultSet => Option[B3],
+    extractTo4: WrappedResultSet => Option[B4],
+    extractTo5: WrappedResultSet => Option[B5],
+    extractTo6: WrappedResultSet => Option[B6])(
+    transform: (A, Seq[B1], Seq[B2], Seq[B3], Seq[B4], Seq[B5], Seq[B6]) => Z)(
+    implicit
+    cxt: EC = ECGlobal): Future[Iterable[Z]] = {
     val _parameters = ensureAndNormalizeParameters(parameters)
     withListeners(statement, _parameters) {
       queryLogging(statement, _parameters)
@@ -386,7 +480,7 @@ trait AsyncDBSession extends LogSupport {
       }
       connection.sendPreparedStatement(statement, _parameters: _*).map { result =>
         result.rows.map { ars =>
-          new AsyncResultSetTraversable(ars).foldLeft(
+          new AsyncResultSetIterator(ars).foldLeft(
             LinkedHashMap[A, (Seq[B1], Seq[B2], Seq[B3], Seq[B4], Seq[B5], Seq[B6])]())(processResultSet).map {
               case (one, (t1, t2, t3, t4, t5, t6)) => transform(one, t1, t2, t3, t4, t5, t6)
             }
@@ -395,20 +489,44 @@ trait AsyncDBSession extends LogSupport {
     }
   }
 
+  @deprecated("will be removed. use oneToManies7Iterable", "0.12.0")
   def oneToManies7Traversable[A, B1, B2, B3, B4, B5, B6, B7, Z](
     statement: String,
     parameters: Any*)(
-    extractOne: (WrappedResultSet) => A)(
-    extractTo1: (WrappedResultSet) => Option[B1],
-    extractTo2: (WrappedResultSet) => Option[B2],
-    extractTo3: (WrappedResultSet) => Option[B3],
-    extractTo4: (WrappedResultSet) => Option[B4],
-    extractTo5: (WrappedResultSet) => Option[B5],
-    extractTo6: (WrappedResultSet) => Option[B6],
-    extractTo7: (WrappedResultSet) => Option[B7])(
+    extractOne: WrappedResultSet => A)(
+    extractTo1: WrappedResultSet => Option[B1],
+    extractTo2: WrappedResultSet => Option[B2],
+    extractTo3: WrappedResultSet => Option[B3],
+    extractTo4: WrappedResultSet => Option[B4],
+    extractTo5: WrappedResultSet => Option[B5],
+    extractTo6: WrappedResultSet => Option[B6],
+    extractTo7: WrappedResultSet => Option[B7])(
     transform: (A, Seq[B1], Seq[B2], Seq[B3], Seq[B4], Seq[B5], Seq[B6], Seq[B7]) => Z)(
     implicit
-    cxt: EC = ECGlobal): Future[Traversable[Z]] = {
+    cxt: EC = ECGlobal): Future[Iterable[Z]] =
+    oneToManies7Iterable[A, B1, B2, B3, B4, B5, B6, B7, Z](statement, parameters: _*)(extractOne)(
+      extractTo1,
+      extractTo2,
+      extractTo3,
+      extractTo4,
+      extractTo5,
+      extractTo6,
+      extractTo7)(transform)
+
+  def oneToManies7Iterable[A, B1, B2, B3, B4, B5, B6, B7, Z](
+    statement: String,
+    parameters: Any*)(
+    extractOne: WrappedResultSet => A)(
+    extractTo1: WrappedResultSet => Option[B1],
+    extractTo2: WrappedResultSet => Option[B2],
+    extractTo3: WrappedResultSet => Option[B3],
+    extractTo4: WrappedResultSet => Option[B4],
+    extractTo5: WrappedResultSet => Option[B5],
+    extractTo6: WrappedResultSet => Option[B6],
+    extractTo7: WrappedResultSet => Option[B7])(
+    transform: (A, Seq[B1], Seq[B2], Seq[B3], Seq[B4], Seq[B5], Seq[B6], Seq[B7]) => Z)(
+    implicit
+    cxt: EC = ECGlobal): Future[Iterable[Z]] = {
     val _parameters = ensureAndNormalizeParameters(parameters)
     withListeners(statement, _parameters) {
       queryLogging(statement, _parameters)
@@ -451,7 +569,7 @@ trait AsyncDBSession extends LogSupport {
       }
       connection.sendPreparedStatement(statement, _parameters: _*).map { result =>
         result.rows.map { ars =>
-          new AsyncResultSetTraversable(ars).foldLeft(
+          new AsyncResultSetIterator(ars).foldLeft(
             LinkedHashMap[A, (Seq[B1], Seq[B2], Seq[B3], Seq[B4], Seq[B5], Seq[B6], Seq[B7])]())(processResultSet).map {
               case (one, (t1, t2, t3, t4, t5, t6, t7)) => transform(one, t1, t2, t3, t4, t5, t6, t7)
             }
@@ -460,21 +578,47 @@ trait AsyncDBSession extends LogSupport {
     }
   }
 
+  @deprecated("will be removed. use oneToManies8Iterable", "0.12.0")
   def oneToManies8Traversable[A, B1, B2, B3, B4, B5, B6, B7, B8, Z](
     statement: String,
     parameters: Any*)(
-    extractOne: (WrappedResultSet) => A)(
-    extractTo1: (WrappedResultSet) => Option[B1],
-    extractTo2: (WrappedResultSet) => Option[B2],
-    extractTo3: (WrappedResultSet) => Option[B3],
-    extractTo4: (WrappedResultSet) => Option[B4],
-    extractTo5: (WrappedResultSet) => Option[B5],
-    extractTo6: (WrappedResultSet) => Option[B6],
-    extractTo7: (WrappedResultSet) => Option[B7],
-    extractTo8: (WrappedResultSet) => Option[B8])(
+    extractOne: WrappedResultSet => A)(
+    extractTo1: WrappedResultSet => Option[B1],
+    extractTo2: WrappedResultSet => Option[B2],
+    extractTo3: WrappedResultSet => Option[B3],
+    extractTo4: WrappedResultSet => Option[B4],
+    extractTo5: WrappedResultSet => Option[B5],
+    extractTo6: WrappedResultSet => Option[B6],
+    extractTo7: WrappedResultSet => Option[B7],
+    extractTo8: WrappedResultSet => Option[B8])(
     transform: (A, Seq[B1], Seq[B2], Seq[B3], Seq[B4], Seq[B5], Seq[B6], Seq[B7], Seq[B8]) => Z)(
     implicit
-    cxt: EC = ECGlobal): Future[Traversable[Z]] = {
+    cxt: EC = ECGlobal): Future[Iterable[Z]] =
+    oneToManies8Iterable[A, B1, B2, B3, B4, B5, B6, B7, B8, Z](statement, parameters: _*)(extractOne)(
+      extractTo1,
+      extractTo2,
+      extractTo3,
+      extractTo4,
+      extractTo5,
+      extractTo6,
+      extractTo7,
+      extractTo8)(transform)
+
+  def oneToManies8Iterable[A, B1, B2, B3, B4, B5, B6, B7, B8, Z](
+    statement: String,
+    parameters: Any*)(
+    extractOne: WrappedResultSet => A)(
+    extractTo1: WrappedResultSet => Option[B1],
+    extractTo2: WrappedResultSet => Option[B2],
+    extractTo3: WrappedResultSet => Option[B3],
+    extractTo4: WrappedResultSet => Option[B4],
+    extractTo5: WrappedResultSet => Option[B5],
+    extractTo6: WrappedResultSet => Option[B6],
+    extractTo7: WrappedResultSet => Option[B7],
+    extractTo8: WrappedResultSet => Option[B8])(
+    transform: (A, Seq[B1], Seq[B2], Seq[B3], Seq[B4], Seq[B5], Seq[B6], Seq[B7], Seq[B8]) => Z)(
+    implicit
+    cxt: EC = ECGlobal): Future[Iterable[Z]] = {
     val _parameters = ensureAndNormalizeParameters(parameters)
     withListeners(statement, _parameters) {
       queryLogging(statement, _parameters)
@@ -520,7 +664,7 @@ trait AsyncDBSession extends LogSupport {
       }
       connection.sendPreparedStatement(statement, _parameters: _*).map { result =>
         result.rows.map { ars =>
-          new AsyncResultSetTraversable(ars).foldLeft(
+          new AsyncResultSetIterator(ars).foldLeft(
             LinkedHashMap[A, (Seq[B1], Seq[B2], Seq[B3], Seq[B4], Seq[B5], Seq[B6], Seq[B7], Seq[B8])]())(processResultSet).map {
               case (one, (t1, t2, t3, t4, t5, t6, t7, t8)) => transform(one, t1, t2, t3, t4, t5, t6, t7, t8)
             }
@@ -529,22 +673,50 @@ trait AsyncDBSession extends LogSupport {
     }
   }
 
+  @deprecated("will be removed. use oneToManies9Iterable", "0.12.0")
   def oneToManies9Traversable[A, B1, B2, B3, B4, B5, B6, B7, B8, B9, Z](
     statement: String,
     parameters: Any*)(
-    extractOne: (WrappedResultSet) => A)(
-    extractTo1: (WrappedResultSet) => Option[B1],
-    extractTo2: (WrappedResultSet) => Option[B2],
-    extractTo3: (WrappedResultSet) => Option[B3],
-    extractTo4: (WrappedResultSet) => Option[B4],
-    extractTo5: (WrappedResultSet) => Option[B5],
-    extractTo6: (WrappedResultSet) => Option[B6],
-    extractTo7: (WrappedResultSet) => Option[B7],
-    extractTo8: (WrappedResultSet) => Option[B8],
-    extractTo9: (WrappedResultSet) => Option[B9])(
+    extractOne: WrappedResultSet => A)(
+    extractTo1: WrappedResultSet => Option[B1],
+    extractTo2: WrappedResultSet => Option[B2],
+    extractTo3: WrappedResultSet => Option[B3],
+    extractTo4: WrappedResultSet => Option[B4],
+    extractTo5: WrappedResultSet => Option[B5],
+    extractTo6: WrappedResultSet => Option[B6],
+    extractTo7: WrappedResultSet => Option[B7],
+    extractTo8: WrappedResultSet => Option[B8],
+    extractTo9: WrappedResultSet => Option[B9])(
     transform: (A, Seq[B1], Seq[B2], Seq[B3], Seq[B4], Seq[B5], Seq[B6], Seq[B7], Seq[B8], Seq[B9]) => Z)(
     implicit
-    cxt: EC = ECGlobal): Future[Traversable[Z]] = {
+    cxt: EC = ECGlobal): Future[Iterable[Z]] =
+    oneToManies9Iterable[A, B1, B2, B3, B4, B5, B6, B7, B8, B9, Z](statement, parameters: _*)(extractOne)(
+      extractTo1,
+      extractTo2,
+      extractTo3,
+      extractTo4,
+      extractTo5,
+      extractTo6,
+      extractTo7,
+      extractTo8,
+      extractTo9)(transform)
+
+  def oneToManies9Iterable[A, B1, B2, B3, B4, B5, B6, B7, B8, B9, Z](
+    statement: String,
+    parameters: Any*)(
+    extractOne: WrappedResultSet => A)(
+    extractTo1: WrappedResultSet => Option[B1],
+    extractTo2: WrappedResultSet => Option[B2],
+    extractTo3: WrappedResultSet => Option[B3],
+    extractTo4: WrappedResultSet => Option[B4],
+    extractTo5: WrappedResultSet => Option[B5],
+    extractTo6: WrappedResultSet => Option[B6],
+    extractTo7: WrappedResultSet => Option[B7],
+    extractTo8: WrappedResultSet => Option[B8],
+    extractTo9: WrappedResultSet => Option[B9])(
+    transform: (A, Seq[B1], Seq[B2], Seq[B3], Seq[B4], Seq[B5], Seq[B6], Seq[B7], Seq[B8], Seq[B9]) => Z)(
+    implicit
+    cxt: EC = ECGlobal): Future[Iterable[Z]] = {
     val _parameters = ensureAndNormalizeParameters(parameters)
     withListeners(statement, _parameters) {
       queryLogging(statement, _parameters)
@@ -593,7 +765,7 @@ trait AsyncDBSession extends LogSupport {
       }
       connection.sendPreparedStatement(statement, _parameters: _*).map { result =>
         result.rows.map { ars =>
-          new AsyncResultSetTraversable(ars).foldLeft(
+          new AsyncResultSetIterator(ars).foldLeft(
             LinkedHashMap[A, (Seq[B1], Seq[B2], Seq[B3], Seq[B4], Seq[B5], Seq[B6], Seq[B7], Seq[B8], Seq[B9])]())(processResultSet).map {
               case (one, (t1, t2, t3, t4, t5, t6, t7, t8, t9)) => transform(one, t1, t2, t3, t4, t5, t6, t7, t8, t9)
             }

--- a/core/src/main/scala/scalikejdbc/async/AsyncRelationalSQLs.scala
+++ b/core/src/main/scala/scalikejdbc/async/AsyncRelationalSQLs.scala
@@ -27,7 +27,7 @@ class AsyncOneToOneSQLToOption[A, B, Z](val underlying: OneToOneSQLToOption[A, B
   extends AnyVal
   with AsyncSQLToOption[Z] {
   override def future()(implicit session: AsyncDBSession, cxt: EC = ECGlobal): Future[Option[Z]] = {
-    session.oneToOneTraversable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(underlying.extractTo)(underlying.transform).map {
+    session.oneToOneIterable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(underlying.extractTo)(underlying.transform).map {
       results =>
         results match {
           case Nil => None
@@ -38,14 +38,14 @@ class AsyncOneToOneSQLToOption[A, B, Z](val underlying: OneToOneSQLToOption[A, B
   }
 }
 
-class AsyncOneToOneSQLToTraversable[A, B, Z](val underlying: OneToOneSQLToTraversable[A, B, HasExtractor, Z])
+class AsyncOneToOneSQLToIterable[A, B, Z](val underlying: OneToOneSQLToIterable[A, B, HasExtractor, Z])
   extends AnyVal
-  with AsyncSQLToTraversable[Z] {
+  with AsyncSQLToIterable[Z] {
   override def future()(implicit
     session: AsyncDBSession,
-    cxt: EC = ECGlobal): Future[Traversable[Z]] = {
-    val traversable = session.oneToOneTraversable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(underlying.extractTo)(underlying.transform)
-    traversable.asInstanceOf[Future[Traversable[Z]]]
+    cxt: EC = ECGlobal): Future[Iterable[Z]] = {
+    val iterable = session.oneToOneIterable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(underlying.extractTo)(underlying.transform)
+    iterable.asInstanceOf[Future[Iterable[Z]]]
   }
 }
 
@@ -53,8 +53,8 @@ class AsyncOneToOneSQLToList[A, B, Z](val underlying: OneToOneSQLToList[A, B, Ha
   extends AnyVal
   with AsyncSQLToList[Z] {
   override def future()(implicit session: AsyncDBSession, cxt: EC = ECGlobal): Future[List[Z]] = {
-    val traversable = session.oneToOneTraversable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(underlying.extractTo)(underlying.transform)
-    traversable.map(_.toList)
+    val iterable = session.oneToOneIterable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(underlying.extractTo)(underlying.transform)
+    iterable.map(_.toList)
   }
 }
 // -------------------
@@ -65,7 +65,7 @@ class AsyncOneToManySQLToOption[A, B, Z](val underlying: OneToManySQLToOption[A,
   extends AnyVal
   with AsyncSQLToOption[Z] {
   override def future()(implicit session: AsyncDBSession, cxt: EC = ECGlobal): Future[Option[Z]] = {
-    session.oneToManyTraversable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(underlying.extractTo)(underlying.transform).map {
+    session.oneToManyIterable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(underlying.extractTo)(underlying.transform).map {
       results =>
         results match {
           case Nil => None
@@ -76,13 +76,13 @@ class AsyncOneToManySQLToOption[A, B, Z](val underlying: OneToManySQLToOption[A,
   }
 }
 
-class AsyncOneToManySQLToTraversable[A, B, Z](val underlying: OneToManySQLToTraversable[A, B, HasExtractor, Z])
+class AsyncOneToManySQLToIterable[A, B, Z](val underlying: OneToManySQLToIterable[A, B, HasExtractor, Z])
   extends AnyVal
-  with AsyncSQLToTraversable[Z] {
+  with AsyncSQLToIterable[Z] {
   override def future()(implicit
     session: AsyncDBSession,
-    cxt: EC = ECGlobal): Future[Traversable[Z]] = {
-    session.oneToManyTraversable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(underlying.extractTo)(underlying.transform)
+    cxt: EC = ECGlobal): Future[Iterable[Z]] = {
+    session.oneToManyIterable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(underlying.extractTo)(underlying.transform)
   }
 }
 
@@ -90,8 +90,8 @@ class AsyncOneToManySQLToList[A, B, Z](val underlying: OneToManySQLToList[A, B, 
   extends AnyVal
   with AsyncSQLToList[Z] {
   override def future()(implicit session: AsyncDBSession, cxt: EC = ECGlobal): Future[List[Z]] = {
-    val traversable = session.oneToManyTraversable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(underlying.extractTo)(underlying.transform)
-    traversable.map(_.toList)
+    val iterable = session.oneToManyIterable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(underlying.extractTo)(underlying.transform)
+    iterable.map(_.toList)
   }
 }
 
@@ -103,7 +103,7 @@ class AsyncOneToManies2SQLToOption[A, B1, B2, Z](val underlying: OneToManies2SQL
   extends AnyVal
   with AsyncSQLToOption[Z] {
   override def future()(implicit session: AsyncDBSession, cxt: EC = ECGlobal): Future[Option[Z]] = {
-    session.oneToManies2Traversable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(underlying.extractTo1, underlying.extractTo2)(underlying.transform).map {
+    session.oneToManies2Iterable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(underlying.extractTo1, underlying.extractTo2)(underlying.transform).map {
       results =>
         results match {
           case Nil => None
@@ -114,12 +114,12 @@ class AsyncOneToManies2SQLToOption[A, B1, B2, Z](val underlying: OneToManies2SQL
   }
 }
 
-class AsyncOneToManies2SQLToTraversable[A, B1, B2, Z](val underlying: OneToManies2SQLToTraversable[A, B1, B2, HasExtractor, Z])
+class AsyncOneToManies2SQLToIterable[A, B1, B2, Z](val underlying: OneToManies2SQLToIterable[A, B1, B2, HasExtractor, Z])
   extends AnyVal
-  with AsyncSQLToTraversable[Z] {
-  override def future()(implicit session: AsyncDBSession, cxt: EC = ECGlobal): Future[Traversable[Z]] = {
-    val traversable = session.oneToManies2Traversable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(underlying.extractTo1, underlying.extractTo2)(underlying.transform)
-    traversable
+  with AsyncSQLToIterable[Z] {
+  override def future()(implicit session: AsyncDBSession, cxt: EC = ECGlobal): Future[Iterable[Z]] = {
+    val iterable = session.oneToManies2Iterable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(underlying.extractTo1, underlying.extractTo2)(underlying.transform)
+    iterable
   }
 }
 
@@ -127,8 +127,8 @@ class AsyncOneToManies2SQLToList[A, B1, B2, Z](val underlying: OneToManies2SQLTo
   extends AnyVal
   with AsyncSQLToList[Z] {
   override def future()(implicit session: AsyncDBSession, cxt: EC = ECGlobal): Future[List[Z]] = {
-    val traversable = session.oneToManies2Traversable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(underlying.extractTo1, underlying.extractTo2)(underlying.transform)
-    traversable.map(_.toList)
+    val iterable = session.oneToManies2Iterable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(underlying.extractTo1, underlying.extractTo2)(underlying.transform)
+    iterable.map(_.toList)
   }
 }
 
@@ -140,7 +140,7 @@ class AsyncOneToManies3SQLToOption[A, B1, B2, B3, Z](val underlying: OneToManies
   extends AnyVal
   with AsyncSQLToOption[Z] {
   override def future()(implicit session: AsyncDBSession, cxt: EC = ECGlobal): Future[Option[Z]] = {
-    session.oneToManies3Traversable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
+    session.oneToManies3Iterable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
       underlying.extractTo1, underlying.extractTo2, underlying.extractTo3)(underlying.transform).map {
         results =>
           results match {
@@ -152,11 +152,11 @@ class AsyncOneToManies3SQLToOption[A, B1, B2, B3, Z](val underlying: OneToManies
   }
 }
 
-class AsyncOneToManies3SQLToTraversable[A, B1, B2, B3, Z](val underlying: OneToManies3SQLToTraversable[A, B1, B2, B3, HasExtractor, Z])
+class AsyncOneToManies3SQLToIterable[A, B1, B2, B3, Z](val underlying: OneToManies3SQLToIterable[A, B1, B2, B3, HasExtractor, Z])
   extends AnyVal
-  with AsyncSQLToTraversable[Z] {
-  override def future()(implicit session: AsyncDBSession, cxt: EC = ECGlobal): Future[Traversable[Z]] = {
-    session.oneToManies3Traversable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
+  with AsyncSQLToIterable[Z] {
+  override def future()(implicit session: AsyncDBSession, cxt: EC = ECGlobal): Future[Iterable[Z]] = {
+    session.oneToManies3Iterable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
       underlying.extractTo1, underlying.extractTo2, underlying.extractTo3)(underlying.transform)
   }
 }
@@ -165,9 +165,9 @@ class AsyncOneToManies3SQLToList[A, B1, B2, B3, Z](val underlying: OneToManies3S
   extends AnyVal
   with AsyncSQLToList[Z] {
   override def future()(implicit session: AsyncDBSession, cxt: EC = ECGlobal): Future[List[Z]] = {
-    val traversable = session.oneToManies3Traversable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
+    val iterable = session.oneToManies3Iterable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
       underlying.extractTo1, underlying.extractTo2, underlying.extractTo3)(underlying.transform)
-    traversable.map(_.toList)
+    iterable.map(_.toList)
   }
 }
 
@@ -179,7 +179,7 @@ class AsyncOneToManies4SQLToOption[A, B1, B2, B3, B4, Z](val underlying: OneToMa
   extends AnyVal
   with AsyncSQLToOption[Z] {
   override def future()(implicit session: AsyncDBSession, cxt: EC = ECGlobal): Future[Option[Z]] = {
-    session.oneToManies4Traversable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
+    session.oneToManies4Iterable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
       underlying.extractTo1, underlying.extractTo2, underlying.extractTo3, underlying.extractTo4)(underlying.transform).map {
         results =>
           results match {
@@ -191,11 +191,11 @@ class AsyncOneToManies4SQLToOption[A, B1, B2, B3, B4, Z](val underlying: OneToMa
   }
 }
 
-class AsyncOneToManies4SQLToTraversable[A, B1, B2, B3, B4, Z](val underlying: OneToManies4SQLToTraversable[A, B1, B2, B3, B4, HasExtractor, Z])
+class AsyncOneToManies4SQLToIterable[A, B1, B2, B3, B4, Z](val underlying: OneToManies4SQLToIterable[A, B1, B2, B3, B4, HasExtractor, Z])
   extends AnyVal
-  with AsyncSQLToTraversable[Z] {
-  override def future()(implicit session: AsyncDBSession, cxt: EC = ECGlobal): Future[Traversable[Z]] = {
-    session.oneToManies4Traversable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
+  with AsyncSQLToIterable[Z] {
+  override def future()(implicit session: AsyncDBSession, cxt: EC = ECGlobal): Future[Iterable[Z]] = {
+    session.oneToManies4Iterable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
       underlying.extractTo1, underlying.extractTo2, underlying.extractTo3, underlying.extractTo4)(underlying.transform)
   }
 }
@@ -204,9 +204,9 @@ class AsyncOneToManies4SQLToList[A, B1, B2, B3, B4, Z](val underlying: OneToMani
   extends AnyVal
   with AsyncSQLToList[Z] {
   override def future()(implicit session: AsyncDBSession, cxt: EC = ECGlobal): Future[List[Z]] = {
-    val traversable = session.oneToManies4Traversable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
+    val iterable = session.oneToManies4Iterable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
       underlying.extractTo1, underlying.extractTo2, underlying.extractTo3, underlying.extractTo4)(underlying.transform)
-    traversable.map(_.toList)
+    iterable.map(_.toList)
   }
 }
 
@@ -218,7 +218,7 @@ class AsyncOneToManies5SQLToOption[A, B1, B2, B3, B4, B5, Z](val underlying: One
   extends AnyVal
   with AsyncSQLToOption[Z] {
   override def future()(implicit session: AsyncDBSession, cxt: EC = ECGlobal): Future[Option[Z]] = {
-    session.oneToManies5Traversable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
+    session.oneToManies5Iterable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
       underlying.extractTo1, underlying.extractTo2, underlying.extractTo3, underlying.extractTo4, underlying.extractTo5)(underlying.transform).map {
         results =>
           results match {
@@ -230,11 +230,11 @@ class AsyncOneToManies5SQLToOption[A, B1, B2, B3, B4, B5, Z](val underlying: One
   }
 }
 
-class AsyncOneToManies5SQLToTraversable[A, B1, B2, B3, B4, B5, Z](val underlying: OneToManies5SQLToTraversable[A, B1, B2, B3, B4, B5, HasExtractor, Z])
+class AsyncOneToManies5SQLToIterable[A, B1, B2, B3, B4, B5, Z](val underlying: OneToManies5SQLToIterable[A, B1, B2, B3, B4, B5, HasExtractor, Z])
   extends AnyVal
-  with AsyncSQLToTraversable[Z] {
-  override def future()(implicit session: AsyncDBSession, cxt: EC = ECGlobal): Future[Traversable[Z]] = {
-    session.oneToManies5Traversable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
+  with AsyncSQLToIterable[Z] {
+  override def future()(implicit session: AsyncDBSession, cxt: EC = ECGlobal): Future[Iterable[Z]] = {
+    session.oneToManies5Iterable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
       underlying.extractTo1, underlying.extractTo2, underlying.extractTo3, underlying.extractTo4, underlying.extractTo5)(underlying.transform)
   }
 }
@@ -243,9 +243,9 @@ class AsyncOneToManies5SQLToList[A, B1, B2, B3, B4, B5, Z](val underlying: OneTo
   extends AnyVal
   with AsyncSQLToList[Z] {
   override def future()(implicit session: AsyncDBSession, cxt: EC = ECGlobal): Future[List[Z]] = {
-    val traversable = session.oneToManies5Traversable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
+    val iterable = session.oneToManies5Iterable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
       underlying.extractTo1, underlying.extractTo2, underlying.extractTo3, underlying.extractTo4, underlying.extractTo5)(underlying.transform)
-    traversable.map(_.toList)
+    iterable.map(_.toList)
   }
 }
 
@@ -257,7 +257,7 @@ class AsyncOneToManies6SQLToOption[A, B1, B2, B3, B4, B5, B6, Z](val underlying:
   extends AnyVal
   with AsyncSQLToOption[Z] {
   override def future()(implicit session: AsyncDBSession, cxt: EC = ECGlobal): Future[Option[Z]] = {
-    session.oneToManies6Traversable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
+    session.oneToManies6Iterable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
       underlying.extractTo1, underlying.extractTo2, underlying.extractTo3, underlying.extractTo4, underlying.extractTo5, underlying.extractTo6)(underlying.transform).map {
         results =>
           results match {
@@ -269,11 +269,11 @@ class AsyncOneToManies6SQLToOption[A, B1, B2, B3, B4, B5, B6, Z](val underlying:
   }
 }
 
-class AsyncOneToManies6SQLToTraversable[A, B1, B2, B3, B4, B5, B6, Z](val underlying: OneToManies6SQLToTraversable[A, B1, B2, B3, B4, B5, B6, HasExtractor, Z])
+class AsyncOneToManies6SQLToIterable[A, B1, B2, B3, B4, B5, B6, Z](val underlying: OneToManies6SQLToIterable[A, B1, B2, B3, B4, B5, B6, HasExtractor, Z])
   extends AnyVal
-  with AsyncSQLToTraversable[Z] {
-  override def future()(implicit session: AsyncDBSession, cxt: EC = ECGlobal): Future[Traversable[Z]] = {
-    session.oneToManies6Traversable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
+  with AsyncSQLToIterable[Z] {
+  override def future()(implicit session: AsyncDBSession, cxt: EC = ECGlobal): Future[Iterable[Z]] = {
+    session.oneToManies6Iterable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
       underlying.extractTo1, underlying.extractTo2, underlying.extractTo3, underlying.extractTo4, underlying.extractTo5, underlying.extractTo6)(underlying.transform)
   }
 }
@@ -282,9 +282,9 @@ class AsyncOneToManies6SQLToList[A, B1, B2, B3, B4, B5, B6, Z](val underlying: O
   extends AnyVal
   with AsyncSQLToList[Z] {
   override def future()(implicit session: AsyncDBSession, cxt: EC = ECGlobal): Future[List[Z]] = {
-    val traversable = session.oneToManies6Traversable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
+    val iterable = session.oneToManies6Iterable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
       underlying.extractTo1, underlying.extractTo2, underlying.extractTo3, underlying.extractTo4, underlying.extractTo5, underlying.extractTo6)(underlying.transform)
-    traversable.map(_.toList)
+    iterable.map(_.toList)
   }
 }
 
@@ -296,7 +296,7 @@ class AsyncOneToManies7SQLToOption[A, B1, B2, B3, B4, B5, B6, B7, Z](val underly
   extends AnyVal
   with AsyncSQLToOption[Z] {
   override def future()(implicit session: AsyncDBSession, cxt: EC = ECGlobal): Future[Option[Z]] = {
-    session.oneToManies7Traversable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
+    session.oneToManies7Iterable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
       underlying.extractTo1, underlying.extractTo2, underlying.extractTo3, underlying.extractTo4, underlying.extractTo5, underlying.extractTo6, underlying.extractTo7)(underlying.transform).map {
         results =>
           results match {
@@ -308,11 +308,11 @@ class AsyncOneToManies7SQLToOption[A, B1, B2, B3, B4, B5, B6, B7, Z](val underly
   }
 }
 
-class AsyncOneToManies7SQLToTraversable[A, B1, B2, B3, B4, B5, B6, B7, Z](val underlying: OneToManies7SQLToTraversable[A, B1, B2, B3, B4, B5, B6, B7, HasExtractor, Z])
+class AsyncOneToManies7SQLToIterable[A, B1, B2, B3, B4, B5, B6, B7, Z](val underlying: OneToManies7SQLToIterable[A, B1, B2, B3, B4, B5, B6, B7, HasExtractor, Z])
   extends AnyVal
-  with AsyncSQLToTraversable[Z] {
-  override def future()(implicit session: AsyncDBSession, cxt: EC = ECGlobal): Future[Traversable[Z]] = {
-    session.oneToManies7Traversable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
+  with AsyncSQLToIterable[Z] {
+  override def future()(implicit session: AsyncDBSession, cxt: EC = ECGlobal): Future[Iterable[Z]] = {
+    session.oneToManies7Iterable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
       underlying.extractTo1, underlying.extractTo2, underlying.extractTo3, underlying.extractTo4, underlying.extractTo5, underlying.extractTo6, underlying.extractTo7)(underlying.transform)
   }
 }
@@ -321,9 +321,9 @@ class AsyncOneToManies7SQLToList[A, B1, B2, B3, B4, B5, B6, B7, Z](val underlyin
   extends AnyVal
   with AsyncSQLToList[Z] {
   override def future()(implicit session: AsyncDBSession, cxt: EC = ECGlobal): Future[List[Z]] = {
-    val traversable = session.oneToManies7Traversable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
+    val iterable = session.oneToManies7Iterable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
       underlying.extractTo1, underlying.extractTo2, underlying.extractTo3, underlying.extractTo4, underlying.extractTo5, underlying.extractTo6, underlying.extractTo7)(underlying.transform)
-    traversable.map(_.toList)
+    iterable.map(_.toList)
   }
 }
 
@@ -335,7 +335,7 @@ class AsyncOneToManies8SQLToOption[A, B1, B2, B3, B4, B5, B6, B7, B8, Z](val und
   extends AnyVal
   with AsyncSQLToOption[Z] {
   override def future()(implicit session: AsyncDBSession, cxt: EC = ECGlobal): Future[Option[Z]] = {
-    session.oneToManies8Traversable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
+    session.oneToManies8Iterable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
       underlying.extractTo1, underlying.extractTo2, underlying.extractTo3, underlying.extractTo4, underlying.extractTo5, underlying.extractTo6, underlying.extractTo7, underlying.extractTo8)(underlying.transform).map {
         results =>
           results match {
@@ -347,11 +347,11 @@ class AsyncOneToManies8SQLToOption[A, B1, B2, B3, B4, B5, B6, B7, B8, Z](val und
   }
 }
 
-class AsyncOneToManies8SQLToTraversable[A, B1, B2, B3, B4, B5, B6, B7, B8, Z](val underlying: OneToManies8SQLToTraversable[A, B1, B2, B3, B4, B5, B6, B7, B8, HasExtractor, Z])
+class AsyncOneToManies8SQLToIterable[A, B1, B2, B3, B4, B5, B6, B7, B8, Z](val underlying: OneToManies8SQLToIterable[A, B1, B2, B3, B4, B5, B6, B7, B8, HasExtractor, Z])
   extends AnyVal
-  with AsyncSQLToTraversable[Z] {
-  override def future()(implicit session: AsyncDBSession, cxt: EC = ECGlobal): Future[Traversable[Z]] = {
-    session.oneToManies8Traversable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
+  with AsyncSQLToIterable[Z] {
+  override def future()(implicit session: AsyncDBSession, cxt: EC = ECGlobal): Future[Iterable[Z]] = {
+    session.oneToManies8Iterable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
       underlying.extractTo1, underlying.extractTo2, underlying.extractTo3, underlying.extractTo4, underlying.extractTo5, underlying.extractTo6, underlying.extractTo7, underlying.extractTo8)(underlying.transform)
   }
 }
@@ -360,9 +360,9 @@ class AsyncOneToManies8SQLToList[A, B1, B2, B3, B4, B5, B6, B7, B8, Z](val under
   extends AnyVal
   with AsyncSQLToList[Z] {
   override def future()(implicit session: AsyncDBSession, cxt: EC = ECGlobal): Future[List[Z]] = {
-    val traversable = session.oneToManies8Traversable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
+    val iterable = session.oneToManies8Iterable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
       underlying.extractTo1, underlying.extractTo2, underlying.extractTo3, underlying.extractTo4, underlying.extractTo5, underlying.extractTo6, underlying.extractTo7, underlying.extractTo8)(underlying.transform)
-    traversable.map(_.toList)
+    iterable.map(_.toList)
   }
 }
 
@@ -374,7 +374,7 @@ class AsyncOneToManies9SQLToOption[A, B1, B2, B3, B4, B5, B6, B7, B8, B9, Z](val
   extends AnyVal
   with AsyncSQLToOption[Z] {
   override def future()(implicit session: AsyncDBSession, cxt: EC = ECGlobal): Future[Option[Z]] = {
-    session.oneToManies9Traversable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
+    session.oneToManies9Iterable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
       underlying.extractTo1, underlying.extractTo2, underlying.extractTo3, underlying.extractTo4, underlying.extractTo5, underlying.extractTo6, underlying.extractTo7, underlying.extractTo8, underlying.extractTo9)(underlying.transform).map {
         results =>
           results match {
@@ -386,11 +386,11 @@ class AsyncOneToManies9SQLToOption[A, B1, B2, B3, B4, B5, B6, B7, B8, B9, Z](val
   }
 }
 
-class AsyncOneToManies9SQLToTraversable[A, B1, B2, B3, B4, B5, B6, B7, B8, B9, Z](val underlying: OneToManies9SQLToTraversable[A, B1, B2, B3, B4, B5, B6, B7, B8, B9, HasExtractor, Z])
+class AsyncOneToManies9SQLToIterable[A, B1, B2, B3, B4, B5, B6, B7, B8, B9, Z](val underlying: OneToManies9SQLToIterable[A, B1, B2, B3, B4, B5, B6, B7, B8, B9, HasExtractor, Z])
   extends AnyVal
-  with AsyncSQLToTraversable[Z] {
-  override def future()(implicit session: AsyncDBSession, cxt: EC = ECGlobal): Future[Traversable[Z]] = {
-    session.oneToManies9Traversable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
+  with AsyncSQLToIterable[Z] {
+  override def future()(implicit session: AsyncDBSession, cxt: EC = ECGlobal): Future[Iterable[Z]] = {
+    session.oneToManies9Iterable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
       underlying.extractTo1, underlying.extractTo2, underlying.extractTo3, underlying.extractTo4, underlying.extractTo5, underlying.extractTo6, underlying.extractTo7, underlying.extractTo8, underlying.extractTo9)(underlying.transform)
   }
 }
@@ -399,8 +399,8 @@ class AsyncOneToManies9SQLToList[A, B1, B2, B3, B4, B5, B6, B7, B8, B9, Z](val u
   extends AnyVal
   with AsyncSQLToList[Z] {
   override def future()(implicit session: AsyncDBSession, cxt: EC = ECGlobal): Future[List[Z]] = {
-    val traversable = session.oneToManies9Traversable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
+    val iterable = session.oneToManies9Iterable(underlying.statement, underlying.rawParameters: _*)(underlying.extractOne)(
       underlying.extractTo1, underlying.extractTo2, underlying.extractTo3, underlying.extractTo4, underlying.extractTo5, underlying.extractTo6, underlying.extractTo7, underlying.extractTo8, underlying.extractTo9)(underlying.transform)
-    traversable.map(_.toList)
+    iterable.map(_.toList)
   }
 }

--- a/core/src/main/scala/scalikejdbc/async/AsyncResultSetIterator.scala
+++ b/core/src/main/scala/scalikejdbc/async/AsyncResultSetIterator.scala
@@ -18,15 +18,16 @@ package scalikejdbc.async
 import scalikejdbc._
 
 /**
- * AsyncResultSet Traversable
+ * AsyncResultSet Iterator
  */
-@deprecated("will be removed. use AsyncResultSetIterator", "0.12.0")
-class AsyncResultSetTraversable(var rs: AsyncResultSet) extends Traversable[WrappedResultSet] {
+class AsyncResultSetIterator(var rs: AsyncResultSet) extends Iterator[WrappedResultSet] {
 
-  def foreach[U](f: (WrappedResultSet) => U): Unit = while (rs.next()) {
-    f.apply(rs)
+  override def hasNext: Boolean = rs.next()
+
+  override def next: WrappedResultSet = {
+    val value = rs
     rs = rs.tail()
+    value
   }
 
 }
-

--- a/core/src/main/scala/scalikejdbc/async/AsyncSQLs.scala
+++ b/core/src/main/scala/scalikejdbc/async/AsyncSQLs.scala
@@ -53,13 +53,13 @@ trait AsyncSQLToOption[A] extends Any {
 }
 class AsyncSQLToOptionImpl[A](val underlying: SQLToOption[A, HasExtractor]) extends AnyVal with AsyncSQLToOption[A]
 
-trait AsyncSQLToTraversable[A] extends Any {
-  def underlying: SQLToTraversable[A, HasExtractor]
-  def future()(implicit session: AsyncDBSession, cxt: EC = ECGlobal): Future[Traversable[A]] = {
-    session.traversable(underlying.statement, underlying.rawParameters: _*)(underlying.extractor)
+trait AsyncSQLToIterable[A] extends Any {
+  def underlying: SQLToIterable[A, HasExtractor]
+  def future()(implicit session: AsyncDBSession, cxt: EC = ECGlobal): Future[Iterable[A]] = {
+    session.iterable(underlying.statement, underlying.rawParameters: _*)(underlying.extractor)
   }
 }
-class AsyncSQLToTraversableImpl[A](val underlying: SQLToTraversable[A, HasExtractor]) extends AnyVal with AsyncSQLToTraversable[A]
+class AsyncSQLToIterableImpl[A](val underlying: SQLToIterable[A, HasExtractor]) extends AnyVal with AsyncSQLToIterable[A]
 
 trait AsyncSQLToList[A] extends Any {
   def underlying: SQLToList[A, HasExtractor]

--- a/core/src/main/scala/scalikejdbc/async/FutureImplicits.scala
+++ b/core/src/main/scala/scalikejdbc/async/FutureImplicits.scala
@@ -22,9 +22,9 @@ import scalikejdbc.async.ShortenedNames._
  */
 object FutureImplicits {
 
-  implicit def fromSQLToTraversableFuture[A](sql: SQL[A, HasExtractor])(
+  implicit def fromSQLToIterableFuture[A](sql: SQL[A, HasExtractor])(
     implicit
-    session: AsyncDBSession, cxt: EC = EC.Implicits.global): Future[Traversable[A]] = sql.traversable.future
+    session: AsyncDBSession, cxt: EC = EC.Implicits.global): Future[Iterable[A]] = sql.iterable.future
 
   implicit def fromSQLToListFuture[A](sql: SQL[A, HasExtractor])(
     implicit

--- a/core/src/main/scala/scalikejdbc/async/package.scala
+++ b/core/src/main/scala/scalikejdbc/async/package.scala
@@ -70,44 +70,44 @@ package object async {
   }
 
   // --------------
-  // one-to-x -> Traversable
+  // one-to-x -> Iterable
   // --------------
 
-  implicit def makeSQLToTraversableAsync[A, B1, B2, B3, B4, B5, Z](sql: SQLToTraversable[A, HasExtractor]): AsyncSQLToTraversable[A] = {
-    new AsyncSQLToTraversableImpl[A](sql)
+  implicit def makeSQLToIterableAsync[A, B1, B2, B3, B4, B5, Z](sql: SQLToIterable[A, HasExtractor]): AsyncSQLToIterable[A] = {
+    new AsyncSQLToIterableImpl[A](sql)
   }
-  implicit def makeSQLToTraversableAsync[A, B1, B2, B3, B4, B5, Z](sql: SQLToTraversableImpl[A, HasExtractor]): AsyncSQLToTraversable[A] = {
-    new AsyncSQLToTraversableImpl[A](sql)
+  implicit def makeSQLToIterableAsync[A, B1, B2, B3, B4, B5, Z](sql: SQLToIterableImpl[A, HasExtractor]): AsyncSQLToIterable[A] = {
+    new AsyncSQLToIterableImpl[A](sql)
   }
-  implicit def makeOneToOneSQLToTraversableAsync[A, B, Z](sql: OneToOneSQLToTraversable[A, B, HasExtractor, Z]): AsyncOneToOneSQLToTraversable[A, B, Z] = {
-    new AsyncOneToOneSQLToTraversable[A, B, Z](sql)
+  implicit def makeOneToOneSQLToIterableAsync[A, B, Z](sql: OneToOneSQLToIterable[A, B, HasExtractor, Z]): AsyncOneToOneSQLToIterable[A, B, Z] = {
+    new AsyncOneToOneSQLToIterable[A, B, Z](sql)
   }
-  implicit def makeOneToManySQLToTraversableAsync[A, B, Z](sql: OneToManySQLToTraversable[A, B, HasExtractor, Z]): AsyncOneToManySQLToTraversable[A, B, Z] = {
-    new AsyncOneToManySQLToTraversable[A, B, Z](sql)
+  implicit def makeOneToManySQLToIterableAsync[A, B, Z](sql: OneToManySQLToIterable[A, B, HasExtractor, Z]): AsyncOneToManySQLToIterable[A, B, Z] = {
+    new AsyncOneToManySQLToIterable[A, B, Z](sql)
   }
-  implicit def makeOneToManies2SQLToTraversableAsync[A, B1, B2, Z](sql: OneToManies2SQLToTraversable[A, B1, B2, HasExtractor, Z]): AsyncOneToManies2SQLToTraversable[A, B1, B2, Z] = {
-    new AsyncOneToManies2SQLToTraversable[A, B1, B2, Z](sql)
+  implicit def makeOneToManies2SQLToIterableAsync[A, B1, B2, Z](sql: OneToManies2SQLToIterable[A, B1, B2, HasExtractor, Z]): AsyncOneToManies2SQLToIterable[A, B1, B2, Z] = {
+    new AsyncOneToManies2SQLToIterable[A, B1, B2, Z](sql)
   }
-  implicit def makeOneToManies3SQLToTraversableAsync[A, B1, B2, B3, Z](sql: OneToManies3SQLToTraversable[A, B1, B2, B3, HasExtractor, Z]): AsyncOneToManies3SQLToTraversable[A, B1, B2, B3, Z] = {
-    new AsyncOneToManies3SQLToTraversable[A, B1, B2, B3, Z](sql)
+  implicit def makeOneToManies3SQLToIterableAsync[A, B1, B2, B3, Z](sql: OneToManies3SQLToIterable[A, B1, B2, B3, HasExtractor, Z]): AsyncOneToManies3SQLToIterable[A, B1, B2, B3, Z] = {
+    new AsyncOneToManies3SQLToIterable[A, B1, B2, B3, Z](sql)
   }
-  implicit def makeOneToManies4SQLToTraversableAsync[A, B1, B2, B3, B4, Z](sql: OneToManies4SQLToTraversable[A, B1, B2, B3, B4, HasExtractor, Z]): AsyncOneToManies4SQLToTraversable[A, B1, B2, B3, B4, Z] = {
-    new AsyncOneToManies4SQLToTraversable[A, B1, B2, B3, B4, Z](sql)
+  implicit def makeOneToManies4SQLToIterableAsync[A, B1, B2, B3, B4, Z](sql: OneToManies4SQLToIterable[A, B1, B2, B3, B4, HasExtractor, Z]): AsyncOneToManies4SQLToIterable[A, B1, B2, B3, B4, Z] = {
+    new AsyncOneToManies4SQLToIterable[A, B1, B2, B3, B4, Z](sql)
   }
-  implicit def makeOneToManies5SQLToTraversableAsync[A, B1, B2, B3, B4, B5, Z](sql: OneToManies5SQLToTraversable[A, B1, B2, B3, B4, B5, HasExtractor, Z]): AsyncOneToManies5SQLToTraversable[A, B1, B2, B3, B4, B5, Z] = {
-    new AsyncOneToManies5SQLToTraversable[A, B1, B2, B3, B4, B5, Z](sql)
+  implicit def makeOneToManies5SQLToIterableAsync[A, B1, B2, B3, B4, B5, Z](sql: OneToManies5SQLToIterable[A, B1, B2, B3, B4, B5, HasExtractor, Z]): AsyncOneToManies5SQLToIterable[A, B1, B2, B3, B4, B5, Z] = {
+    new AsyncOneToManies5SQLToIterable[A, B1, B2, B3, B4, B5, Z](sql)
   }
-  implicit def makeOneToManies6SQLToTraversableAsync[A, B1, B2, B3, B4, B5, B6, Z](sql: OneToManies6SQLToTraversable[A, B1, B2, B3, B4, B5, B6, HasExtractor, Z]): AsyncOneToManies6SQLToTraversable[A, B1, B2, B3, B4, B5, B6, Z] = {
-    new AsyncOneToManies6SQLToTraversable[A, B1, B2, B3, B4, B5, B6, Z](sql)
+  implicit def makeOneToManies6SQLToIterableAsync[A, B1, B2, B3, B4, B5, B6, Z](sql: OneToManies6SQLToIterable[A, B1, B2, B3, B4, B5, B6, HasExtractor, Z]): AsyncOneToManies6SQLToIterable[A, B1, B2, B3, B4, B5, B6, Z] = {
+    new AsyncOneToManies6SQLToIterable[A, B1, B2, B3, B4, B5, B6, Z](sql)
   }
-  implicit def makeOneToManies7SQLToTraversableAsync[A, B1, B2, B3, B4, B5, B6, B7, Z](sql: OneToManies7SQLToTraversable[A, B1, B2, B3, B4, B5, B6, B7, HasExtractor, Z]): AsyncOneToManies7SQLToTraversable[A, B1, B2, B3, B4, B5, B6, B7, Z] = {
-    new AsyncOneToManies7SQLToTraversable[A, B1, B2, B3, B4, B5, B6, B7, Z](sql)
+  implicit def makeOneToManies7SQLToIterableAsync[A, B1, B2, B3, B4, B5, B6, B7, Z](sql: OneToManies7SQLToIterable[A, B1, B2, B3, B4, B5, B6, B7, HasExtractor, Z]): AsyncOneToManies7SQLToIterable[A, B1, B2, B3, B4, B5, B6, B7, Z] = {
+    new AsyncOneToManies7SQLToIterable[A, B1, B2, B3, B4, B5, B6, B7, Z](sql)
   }
-  implicit def makeOneToManies8SQLToTraversableAsync[A, B1, B2, B3, B4, B5, B6, B7, B8, Z](sql: OneToManies8SQLToTraversable[A, B1, B2, B3, B4, B5, B6, B7, B8, HasExtractor, Z]): AsyncOneToManies8SQLToTraversable[A, B1, B2, B3, B4, B5, B6, B7, B8, Z] = {
-    new AsyncOneToManies8SQLToTraversable[A, B1, B2, B3, B4, B5, B6, B7, B8, Z](sql)
+  implicit def makeOneToManies8SQLToIterableAsync[A, B1, B2, B3, B4, B5, B6, B7, B8, Z](sql: OneToManies8SQLToIterable[A, B1, B2, B3, B4, B5, B6, B7, B8, HasExtractor, Z]): AsyncOneToManies8SQLToIterable[A, B1, B2, B3, B4, B5, B6, B7, B8, Z] = {
+    new AsyncOneToManies8SQLToIterable[A, B1, B2, B3, B4, B5, B6, B7, B8, Z](sql)
   }
-  implicit def makeOneToManies9SQLToTraversableAsync[A, B1, B2, B3, B4, B5, B6, B7, B8, B9, Z](sql: OneToManies9SQLToTraversable[A, B1, B2, B3, B4, B5, B6, B7, B8, B9, HasExtractor, Z]): AsyncOneToManies9SQLToTraversable[A, B1, B2, B3, B4, B5, B6, B7, B8, B9, Z] = {
-    new AsyncOneToManies9SQLToTraversable[A, B1, B2, B3, B4, B5, B6, B7, B8, B9, Z](sql)
+  implicit def makeOneToManies9SQLToIterableAsync[A, B1, B2, B3, B4, B5, B6, B7, B8, B9, Z](sql: OneToManies9SQLToIterable[A, B1, B2, B3, B4, B5, B6, B7, B8, B9, HasExtractor, Z]): AsyncOneToManies9SQLToIterable[A, B1, B2, B3, B4, B5, B6, B7, B8, B9, Z] = {
+    new AsyncOneToManies9SQLToIterable[A, B1, B2, B3, B4, B5, B6, B7, B8, B9, Z](sql)
   }
 
   // --------------

--- a/core/src/test/scala/sample/MySQLSampleSpec.scala
+++ b/core/src/test/scala/sample/MySQLSampleSpec.scala
@@ -31,13 +31,13 @@ class MySQLSampleSpec extends FlatSpec with Matchers with DBSettings with Loggin
     result.isDefined should be(true)
   }
 
-  it should "select values as a Traversable" in {
-    val resultsFuture: Future[Traversable[AsyncLover]] = NamedAsyncDB('mysql).withPool { implicit s =>
+  it should "select values as a Iterable" in {
+    val resultsFuture: Future[Iterable[AsyncLover]] = NamedAsyncDB('mysql).withPool { implicit s =>
       withSQL {
         select.from(AsyncLover as al)
           .where.isNotNull(al.birthday) // mysql-async 0.2.4 cannot parse nullable date value.
           .limit(2)
-      }.map(AsyncLover(al)).traversable.future()
+      }.map(AsyncLover(al)).iterable.future()
     }
     val results = Await.result(resultsFuture, 5.seconds)
     results.size should equal(2)

--- a/core/src/test/scala/sample/PostgreSQLSampleSpec.scala
+++ b/core/src/test/scala/sample/PostgreSQLSampleSpec.scala
@@ -30,9 +30,9 @@ class PostgreSQLSampleSpec extends FlatSpec with Matchers with DBSettings with L
     result.isDefined should be(true)
   }
 
-  it should "select values as a Traversable" in {
-    val resultsFuture: Future[Traversable[AsyncLover]] = AsyncDB.withPool { implicit s =>
-      withSQL { select.from(AsyncLover as al).limit(2) }.map(AsyncLover(al)).traversable.future()
+  it should "select values as a Iterable" in {
+    val resultsFuture: Future[Iterable[AsyncLover]] = AsyncDB.withPool { implicit s =>
+      withSQL { select.from(AsyncLover as al).limit(2) }.map(AsyncLover(al)).iterable.future()
     }
     Await.result(resultsFuture, 5.seconds)
     val results = resultsFuture.value.get.get


### PR DESCRIPTION
- Traversable deprecated since Scala 2.13. use Iterable. rename some methods and classes
- add AsyncResultSetIterator. for the same reason https://github.com/scalikejdbc/scalikejdbc/commit/e417858b3f2a888619144a1ab44f67f0a0a9130a#diff-846b86f70457179f4e5d7527ce269b6e
- deprecate AsyncResultSetTraversable