### PR TITLE
Repeating withSQL results in TimeoutException

### DIFF
--- a/core/src/main/scala/scalikejdbc/async/AsyncDBSession.scala
+++ b/core/src/main/scala/scalikejdbc/async/AsyncDBSession.scala
@@ -219,7 +219,10 @@ trait AsyncDBSession extends AsyncDBSessionBoilerplate with LogSupport {
 /**
  * Shared Asynchronous DB session
  */
-case class SharedAsyncDBSession(connection: AsyncConnection) extends AsyncDBSession
+case class SharedAsyncDBSession(pool: AsyncConnectionPool) extends AsyncDBSession {
+  override val connection: AsyncConnection = pool.borrow()
+  def close(): Unit = connection.close()
+}
 
 /**
  * Asynchronous Transactional DB Session

--- a/core/src/test/scala/sample/PostgreSQLSampleSpec.scala
+++ b/core/src/test/scala/sample/PostgreSQLSampleSpec.scala
@@ -30,6 +30,15 @@ class PostgreSQLSampleSpec extends FlatSpec with Matchers with DBSettings with L
     result.isDefined should be(true)
   }
 
+  it should "repeat selecting a single value" in {
+    def resultFuture: Future[Option[AsyncLover]] = AsyncDB.withPool { implicit s =>
+      withSQL { select.from(AsyncLover as al).where.eq(al.id, 1) }.map(AsyncLover(al)).single.future()
+    }
+    val futures = Future.sequence((1 to 9).map(_ => resultFuture))
+    val results = Await.result(futures, 5.seconds)
+    results.foreach(result => result.isDefined should be(true))
+  }
+
   it should "select values as a Iterable" in {
     val resultsFuture: Future[Iterable[AsyncLover]] = AsyncDB.withPool { implicit s =>
       withSQL { select.from(AsyncLover as al).limit(2) }.map(AsyncLover(al)).iterable.future()


### PR DESCRIPTION
Maybe this fixes #86.

I don't understand the design difference between `SharedAsyncDBSession` and `NonSharedAsyncDBSession`. This PR will change `SharedAsyncDBSession`'s API, so some users are affected by this change. But I think `SharedAsyncDBSession` needs an API like` close`.
