### PR TITLE
fix: Repeating withSQL result in TimeoutException

### DIFF
--- a/core/src/main/scala/scalikejdbc/async/internal/AsyncConnectionCommonImpl.scala
+++ b/core/src/main/scala/scalikejdbc/async/internal/AsyncConnectionCommonImpl.scala
@@ -15,22 +15,21 @@
  */
 package scalikejdbc.async.internal
 
-import scalikejdbc.async._
-import ShortenedNames._
-
-import scala.concurrent._
-import duration.DurationInt
 import com.github.jasync.sql.db._
+import scalikejdbc.async.ShortenedNames._
+import scalikejdbc.async._
 
-import scala.compat.java8.FutureConverters._
 import scala.collection.JavaConverters._
+import scala.compat.java8.FutureConverters._
+import scala.concurrent._
+import scala.concurrent.duration.DurationInt
 
 /**
  * Basic Implementation of Asynchronous Connection
  */
 private[scalikejdbc] trait AsyncConnectionCommonImpl extends AsyncConnection {
 
-  private[scalikejdbc] def underlying: ConcreteConnection
+  private[scalikejdbc] def underlying: Connection
   private[scalikejdbc] val defaultTimeout = 10.seconds
 
   override def isActive: Boolean = underlying.isConnected

--- a/core/src/main/scala/scalikejdbc/async/internal/PoolableAsyncConnection.scala
+++ b/core/src/main/scala/scalikejdbc/async/internal/PoolableAsyncConnection.scala
@@ -15,14 +15,12 @@
  */
 package scalikejdbc.async.internal
 
-import java.util.concurrent.TimeUnit
-
+import com.github.jasync.sql.db.ConcreteConnection
 import com.github.jasync.sql.db.pool.ConnectionPool
 import scalikejdbc.async.NonSharedAsyncConnection
-import com.github.jasync.sql.db.ConcreteConnection
+import scalikejdbc.async.ShortenedNames._
 
 import scala.concurrent._
-import scalikejdbc.async.ShortenedNames._
 
 /**
  * AsyncConnection implementation which is based on jasync's Connection
@@ -36,14 +34,11 @@ private[scalikejdbc] abstract class PoolableAsyncConnection[T <: ConcreteConnect
   override def toNonSharedConnection()(implicit cxt: EC = ECGlobal): Future[NonSharedAsyncConnection] =
     Future.failed(new UnsupportedOperationException)
 
-  // TODO make configurable timeout or avoid Future#get
-  private[scalikejdbc] lazy val underlying = pool.take().get(5, TimeUnit.SECONDS)
+  private[scalikejdbc] lazy val underlying = pool
 
   /**
    * Close or release this connection.
    */
-  override def close(): Unit = {
-    pool.giveBack(underlying)
-  }
+  override def close(): Unit = ()
 
 }

--- a/core/src/test/scala/sample/PostgreSQLSampleSpec.scala
+++ b/core/src/test/scala/sample/PostgreSQLSampleSpec.scala
@@ -30,6 +30,15 @@ class PostgreSQLSampleSpec extends FlatSpec with Matchers with DBSettings with L
     result.isDefined should be(true)
   }
 
+  it should "repeat selecting a single value" in {
+    def resultFuture: Future[Option[AsyncLover]] = AsyncDB.withPool { implicit s =>
+      withSQL { select.from(AsyncLover as al).where.eq(al.id, 1) }.map(AsyncLover(al)).single.future()
+    }
+    val futures = Future.sequence((1 to 9).map(_ => resultFuture))
+    val results = Await.result(futures, 5.seconds)
+    results.foreach(result => result.isDefined should be(true))
+  }
+
   it should "select values as a Iterable" in {
     val resultsFuture: Future[Iterable[AsyncLover]] = AsyncDB.withPool { implicit s =>
       withSQL { select.from(AsyncLover as al).limit(2) }.map(AsyncLover(al)).iterable.future()


### PR DESCRIPTION
close #88 
This implementation followed 0.11.x.

Original(0.11.x) implementation used `Connection` for underlying connection. On the other hand, current implementation uses `ConcreteConnection` for that. To cope with the type change, the underlying implementation of `PoolableAsyncConnection` has been changed to get the connection from the pool, but this change seems to be the cause of the bug.

- [0.11.x](https://github.com/scalikejdbc/scalikejdbc-async/blob/0.11.x/core/src/main/scala/scalikejdbc/async/internal/PoolableAsyncConnection.scala#L36)
- [0.12.x](https://github.com/scalikejdbc/scalikejdbc-async/blob/adf7a5e67e67af2252fea049724540f351a5b315/core/src/main/scala/scalikejdbc/async/internal/PoolableAsyncConnection.scala#L40)

When `ConnectionPool` is used as `Connection`, the connection is automatically collected.

- [ConnectionPool](https://github.com/jasync-sql/jasync-sql/blob/aef32fd29aafff0c8cf540b89e4f7f9ad27037d0/db-async-common/src/main/java/com/github/jasync/sql/db/pool/ConnectionPool.kt#L77-L79)
- [AsyncObjectPool](https://github.com/jasync-sql/jasync-sql/blob/ad1396e5f899e4e21f82e873b951f745b5874182/db-async-common/src/main/java/com/github/jasync/sql/db/pool/AsyncObjectPool.kt#L66)



